### PR TITLE
Add Positional Getters

### DIFF
--- a/include/flags.h
+++ b/include/flags.h
@@ -127,6 +127,8 @@ std::optional<bool> get(const argument_map& options,
     return std::none_of(falsities.begin(), falsities.end(),
                         [&value](auto falsity) { return *value == falsity; });
   }
+  if (options.find(option) != options.end())
+      return true;
   return std::nullopt;
 }
 

--- a/include/flags.h
+++ b/include/flags.h
@@ -127,41 +127,44 @@ std::optional<bool> get(const argument_map& options,
     return std::none_of(falsities.begin(), falsities.end(),
                         [&value](auto falsity) { return *value == falsity; });
   }
-  if (options.find(option) != options.end())
-      return true;
+  if (options.find(option) != options.end()) return true;
   return std::nullopt;
 }
-
 
 // Coerces the string value of the given positional index into <T>.
 // If the value cannot be properly parsed or the key does not exist, returns
 // nullopt.
 template <class T>
 std::optional<T> get(const std::vector<std::string_view>& positional_arguments,
-    size_t positional_index) {
-    if (positional_index < positional_arguments.size()) {
-        if (T value; std::istringstream(std::string(positional_arguments[positional_index])) >> value) return value;
-    }
-    return std::nullopt;
+                     size_t positional_index) {
+  if (positional_index < positional_arguments.size()) {
+    if (T value; std::istringstream(
+                     std::string(positional_arguments[positional_index])) >>
+                 value)
+      return value;
+  }
+  return std::nullopt;
 }
 
 // Since the values are already stored as strings, there's no need to use `>>`.
 template <>
-std::optional<std::string_view> get(const std::vector<std::string_view>& positional_arguments,
+std::optional<std::string_view> get(
+    const std::vector<std::string_view>& positional_arguments,
     size_t positional_index) {
-    if (positional_index < positional_arguments.size()) {
-        return positional_arguments[positional_index];
-    }
-    return std::nullopt;
+  if (positional_index < positional_arguments.size()) {
+    return positional_arguments[positional_index];
+  }
+  return std::nullopt;
 }
 
 template <>
-std::optional<std::string> get(const std::vector<std::string_view>& positional_arguments,
+std::optional<std::string> get(
+    const std::vector<std::string_view>& positional_arguments,
     size_t positional_index) {
-    if (positional_index < positional_arguments.size()) {
-        return std::string(positional_arguments[positional_index]);
-    }
-    return std::nullopt;
+  if (positional_index < positional_arguments.size()) {
+    return std::string(positional_arguments[positional_index]);
+  }
+  return std::nullopt;
 }
 }  // namespace detail
 
@@ -180,12 +183,12 @@ struct args {
 
   template <class T>
   std::optional<T> get(size_t positional_index) const {
-      return detail::get<T>(parser_.positional_arguments(), positional_index);
+    return detail::get<T>(parser_.positional_arguments(), positional_index);
   }
 
   template <class T>
   T get(size_t positional_index, T&& default_value) const {
-      return get<T>(positional_index).value_or(default_value);
+    return get<T>(positional_index).value_or(default_value);
   }
 
   const std::vector<std::string_view>& positional() const {

--- a/include/flags.h
+++ b/include/flags.h
@@ -129,6 +129,38 @@ std::optional<bool> get(const argument_map& options,
   }
   return std::nullopt;
 }
+
+
+// Coerces the string value of the given option into <T>.
+// If the value cannot be properly parsed or the key does not exist, returns
+// nullopt.
+template <class T>
+std::optional<T> get(const std::vector<std::string_view>& positional_arguments,
+    size_t positional_index) {
+    if (positional_index < positional_arguments.size()) {
+        if (T value; std::istringstream(std::string(positional_arguments[positional_index])) >> value) return value;
+    }
+    return std::nullopt;
+}
+
+// Since the values are already stored as strings, there's no need to use `>>`.
+template <>
+std::optional<std::string_view> get(const std::vector<std::string_view>& positional_arguments,
+    size_t positional_index) {
+    if (positional_index < positional_arguments.size()) {
+        return positional_arguments[positional_index];
+    }
+    return std::nullopt;
+}
+
+template <>
+std::optional<std::string> get(const std::vector<std::string_view>& positional_arguments,
+    size_t positional_index) {
+    if (positional_index < positional_arguments.size()) {
+        return std::string(positional_arguments[positional_index]);
+    }
+    return std::nullopt;
+}
 }  // namespace detail
 
 struct args {
@@ -142,6 +174,16 @@ struct args {
   template <class T>
   T get(const std::string_view& option, T&& default_value) const {
     return get<T>(option).value_or(default_value);
+  }
+
+  template <class T>
+  std::optional<T> get(size_t positional_index) const {
+      return detail::get<T>(parser_.positional_arguments(), positional_index);
+  }
+
+  template <class T>
+  T get(size_t positional_index, T&& default_value) const {
+      return get<T>(positional_index).value_or(default_value);
   }
 
   const std::vector<std::string_view>& positional() const {

--- a/include/flags.h
+++ b/include/flags.h
@@ -133,7 +133,7 @@ std::optional<bool> get(const argument_map& options,
 }
 
 
-// Coerces the string value of the given option into <T>.
+// Coerces the string value of the given positional index into <T>.
 // If the value cannot be properly parsed or the key does not exist, returns
 // nullopt.
 template <class T>

--- a/test/flags.cc
+++ b/test/flags.cc
@@ -74,6 +74,8 @@ suite<> positional_arguments("positional arguments", [](auto& _) {
     const auto fixture =
         args_fixture::create({"--no", "positional", "--arguments"});
     expect(fixture.args().positional().size(), equal_to(0));
+    expect(fixture.args().get<int>(0), equal_to(std::nullopt));
+    expect(fixture.args().get<int>(0, 3), equal_to(3));
   });
 
   // Testing the existence of positional arguments with no options or flags.
@@ -82,6 +84,13 @@ suite<> positional_arguments("positional arguments", [](auto& _) {
     expect(fixture.args().positional().size(), equal_to(2));
     expect(fixture.args().positional()[0], equal_to("positional"));
     expect(fixture.args().positional()[1], equal_to("arguments"));
+    // Tests for positional getters
+    expect(fixture.args().get<std::string_view>(0), equal_to("positional"));
+    expect(fixture.args().get<std::string_view>(1), equal_to("arguments"));
+    expect(fixture.args().get<std::string_view>(2), equal_to(std::nullopt));
+    expect(fixture.args().get<std::string>(0, "default"), equal_to("positional"));
+    expect(fixture.args().get<std::string>(1, "default"), equal_to("arguments"));
+    expect(fixture.args().get<std::string>(2, "default"), equal_to("default"));
   });
 
   // Adding options to the mix.
@@ -91,6 +100,13 @@ suite<> positional_arguments("positional arguments", [](auto& _) {
     expect(fixture.args().positional().size(), equal_to(2));
     expect(fixture.args().positional()[0], equal_to("positional"));
     expect(fixture.args().positional()[1], equal_to("arguments"));
+    // Tests for positional getters
+    expect(fixture.args().get<std::string_view>(0), equal_to("positional"));
+    expect(fixture.args().get<std::string_view>(1), equal_to("arguments"));
+    expect(fixture.args().get<std::string_view>(2), equal_to(std::nullopt));
+    expect(fixture.args().get<std::string>(0, "default"), equal_to("positional"));
+    expect(fixture.args().get<std::string>(1, "default"), equal_to("arguments"));
+    expect(fixture.args().get<std::string>(2, "default"), equal_to("default"));
   });
 
   // Adding flags to the mix.
@@ -101,6 +117,13 @@ suite<> positional_arguments("positional arguments", [](auto& _) {
     expect(fixture.args().positional().size(), equal_to(2));
     expect(fixture.args().positional()[0], equal_to("positional"));
     expect(fixture.args().positional()[1], equal_to("arguments"));
+    // Tests for positional getters
+    expect(fixture.args().get<std::string_view>(0), equal_to("positional"));
+    expect(fixture.args().get<std::string_view>(1), equal_to("arguments"));
+    expect(fixture.args().get<std::string_view>(2), equal_to(std::nullopt));
+    expect(fixture.args().get<std::string>(0, "default"), equal_to("positional"));
+    expect(fixture.args().get<std::string>(1, "default"), equal_to("arguments"));
+    expect(fixture.args().get<std::string>(2, "default"), equal_to("default"));
   });
 
   // Adding both flags and options.
@@ -111,16 +134,24 @@ suite<> positional_arguments("positional arguments", [](auto& _) {
     expect(fixture.args().positional().size(), equal_to(2));
     expect(fixture.args().positional()[0], equal_to("positional"));
     expect(fixture.args().positional()[1], equal_to("arguments"));
+    // Tests for positional getters
+    expect(fixture.args().get<std::string_view>(0), equal_to("positional"));
+    expect(fixture.args().get<std::string_view>(1), equal_to("arguments"));
+    expect(fixture.args().get<std::string_view>(2), equal_to(std::nullopt));
+    expect(fixture.args().get<std::string>(0, "default"), equal_to("positional"));
+    expect(fixture.args().get<std::string>(1, "default"), equal_to("arguments"));
+    expect(fixture.args().get<std::string>(2, "default"), equal_to("default"));
   });
 });
 
 suite<> flag_parsing("flag parsing", [](auto& _) {
   // Basic bool parsing.
   _.test("bool", []() {
-    const auto fixture = args_fixture::create({"--foo", "1", "--bar", "no"});
+    const auto fixture = args_fixture::create({"--foo", "1", "--bar", "no", "--verbose"});
     expect(*fixture.args().get<bool>("foo"), equal_to(true));
     expect(fixture.args().get<bool>("foo", false), equal_to(true));
     expect(*fixture.args().get<bool>("bar"), equal_to(false));
+    expect(fixture.args().get<bool>("verbose"), equal_to(true));
     expect(fixture.args().get<bool>("nonexistent"), equal_to(std::nullopt));
   });
 

--- a/test/flags.cc
+++ b/test/flags.cc
@@ -1,4 +1,5 @@
 #include "flags.h"
+
 #include <array>
 #include <mettle.hpp>
 #include <stdexcept>
@@ -88,8 +89,10 @@ suite<> positional_arguments("positional arguments", [](auto& _) {
     expect(fixture.args().get<std::string_view>(0), equal_to("positional"));
     expect(fixture.args().get<std::string_view>(1), equal_to("arguments"));
     expect(fixture.args().get<std::string_view>(2), equal_to(std::nullopt));
-    expect(fixture.args().get<std::string>(0, "default"), equal_to("positional"));
-    expect(fixture.args().get<std::string>(1, "default"), equal_to("arguments"));
+    expect(fixture.args().get<std::string>(0, "default"),
+           equal_to("positional"));
+    expect(fixture.args().get<std::string>(1, "default"),
+           equal_to("arguments"));
     expect(fixture.args().get<std::string>(2, "default"), equal_to("default"));
   });
 
@@ -104,8 +107,10 @@ suite<> positional_arguments("positional arguments", [](auto& _) {
     expect(fixture.args().get<std::string_view>(0), equal_to("positional"));
     expect(fixture.args().get<std::string_view>(1), equal_to("arguments"));
     expect(fixture.args().get<std::string_view>(2), equal_to(std::nullopt));
-    expect(fixture.args().get<std::string>(0, "default"), equal_to("positional"));
-    expect(fixture.args().get<std::string>(1, "default"), equal_to("arguments"));
+    expect(fixture.args().get<std::string>(0, "default"),
+           equal_to("positional"));
+    expect(fixture.args().get<std::string>(1, "default"),
+           equal_to("arguments"));
     expect(fixture.args().get<std::string>(2, "default"), equal_to("default"));
   });
 
@@ -121,8 +126,10 @@ suite<> positional_arguments("positional arguments", [](auto& _) {
     expect(fixture.args().get<std::string_view>(0), equal_to("positional"));
     expect(fixture.args().get<std::string_view>(1), equal_to("arguments"));
     expect(fixture.args().get<std::string_view>(2), equal_to(std::nullopt));
-    expect(fixture.args().get<std::string>(0, "default"), equal_to("positional"));
-    expect(fixture.args().get<std::string>(1, "default"), equal_to("arguments"));
+    expect(fixture.args().get<std::string>(0, "default"),
+           equal_to("positional"));
+    expect(fixture.args().get<std::string>(1, "default"),
+           equal_to("arguments"));
     expect(fixture.args().get<std::string>(2, "default"), equal_to("default"));
   });
 
@@ -138,8 +145,10 @@ suite<> positional_arguments("positional arguments", [](auto& _) {
     expect(fixture.args().get<std::string_view>(0), equal_to("positional"));
     expect(fixture.args().get<std::string_view>(1), equal_to("arguments"));
     expect(fixture.args().get<std::string_view>(2), equal_to(std::nullopt));
-    expect(fixture.args().get<std::string>(0, "default"), equal_to("positional"));
-    expect(fixture.args().get<std::string>(1, "default"), equal_to("arguments"));
+    expect(fixture.args().get<std::string>(0, "default"),
+           equal_to("positional"));
+    expect(fixture.args().get<std::string>(1, "default"),
+           equal_to("arguments"));
     expect(fixture.args().get<std::string>(2, "default"), equal_to("default"));
   });
 });
@@ -147,11 +156,12 @@ suite<> positional_arguments("positional arguments", [](auto& _) {
 suite<> flag_parsing("flag parsing", [](auto& _) {
   // Basic bool parsing.
   _.test("bool", []() {
-    const auto fixture = args_fixture::create({"--foo", "1", "--bar", "no", "--verbose"});
+    const auto fixture =
+        args_fixture::create({"--foo", "1", "--bar", "no", "--verbose"});
     expect(*fixture.args().get<bool>("foo"), equal_to(true));
     expect(fixture.args().get<bool>("foo", false), equal_to(true));
     expect(*fixture.args().get<bool>("bar"), equal_to(false));
-    expect(fixture.args().get<bool>("verbose"), equal_to(true));
+    expect(*fixture.args().get<bool>("verbose"), equal_to(true));
     expect(fixture.args().get<bool>("nonexistent"), equal_to(std::nullopt));
   });
 


### PR DESCRIPTION
Since only options can be retrieved by the template `get<T>` functions, positional arguments needs to be manually parsed which added unneeded verbosity to the code.

This pull request adds the following functions:
- `std::optional<T> args::get<T>(size_t positional_index)`
- `T args::get<T>(size_t positional_index, , T&& default_value)`

If the `positional_index` doesn't exist an `std::nullopt` or the default value is returned.

Also this pull request contains a fix for #8 and adds test cases for the aforementioned functions and fix.