### PR TITLE
Add Support for CMake Builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,59 @@
+cmake_minimum_required(VERSION 3.12)
+
+project(
+  flags
+  VERSION
+    1.0.0
+    DESCRIPTION
+    "Simple, extensible, header-only C++17 argument parser released into the public domain."
+    HOMEPAGE_URL
+    "https://github.com/sailormoon/flags")
+
+add_library(${PROJECT_NAME} INTERFACE)
+
+# Add alias so the project can be used with add_subdirectory
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+include(GNUInstallDirs)
+
+# Adding the install interface generator expression makes sure that the include
+# files are installed to the proper location (provided by GNUInstallDirs)
+target_include_directories(
+  ${PROJECT_NAME}
+  INTERFACE $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_17)
+
+# Locations are provided by GNUInstallDirs
+install(TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}_Targets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("${PROJECT_NAME}ConfigVersion.cmake"
+                                 VERSION ${PROJECT_VERSION}
+                                 COMPATIBILITY SameMajorVersion)
+
+configure_package_config_file(
+  "${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in"
+  "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+  INSTALL_DESTINATION
+  ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
+
+install(EXPORT ${PROJECT_NAME}_Targets
+        FILE ${PROJECT_NAME}Targets.cmake
+        NAMESPACE ${PROJECT_NAME}::
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
+
+install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+              "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
+
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME} DESTINATION include)
+
+set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
+
+include(CPack)

--- a/README.md
+++ b/README.md
@@ -58,12 +58,61 @@ Returns all of the positional arguments from argv in order.
 ### just the headers
 Just include `flags.h` from the `include` directory into your project.
 
-### CMake
-You can also use this project in cmake as a submodule or as a fully-installed module.
+## Using CMake
+
+### CMake Installation
+
+Flags can be built and installed using [CMake], e.g.
+
+```sh
+$ mkdir build
+$ cd build
+$ cmake ..
+$ make
+$ make install
+```
+
+The above will install Flags into the standard installation path on a UNIX
+system, e.g. `/usr/local/include/`. To change the installation path, use:
+
+```sh
+$ cmake .. -DCMAKE_INSTALL_PREFIX=../install
+```
+
+in the above.
+
+### `find_package`
+
+Installation creates a `flags-config.cmake` which allows CMake
+projects to find Flags using `find_package`:
+
+```cmake
+find_package(flags)
+```
+
+This exports the `flags` target which can be linked against any other
+target. Linking against `flags` automatically sets the include
+directories and required flags for C++17 or later. For example:
+
+```cmake
+add_executable(myexe mysources...)
+target_link_libraries(myexe PRIVATE flags)
+```
+
+### `add_subdirectory`
+
+The Flags can also be added as a dependency with `add_subdirectory`:
+
+```cmake
+add_subdirectory(path/to/flags)
+```
+
+This also exports the `flags` target which can be linked against any
+other target just as with the installation case.
 
 ## example
 ```c++
-#include "flags.h"
+#include "flags.h" // #include <flags.h> for cmake
 #include <iostream>
 
 int main(int argc, char** argv) {
@@ -94,7 +143,7 @@ $ ./program --count=5 --laugh
 
 ## another example
 ```c++
-#include "flags.h"
+#include "flags.h" // #include <flags.h> for cmake
 #include <iostream>
 #include <string>
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,11 @@ Functions the same as `get`, except if the value is malformed or the key was not
 Returns all of the positional arguments from argv in order.
 
 # usage
+### just the headers
 Just include `flags.h` from the `include` directory into your project.
+
+### CMake
+You can also use this project in cmake as a submodule or as a fully-installed module.
 
 ## example
 ```c++
@@ -110,7 +114,7 @@ int main(int argc, char** argv) {
 ```
 ```bash
 $ ./program /tmp/one /tmp/two /tmp/three --verbose
-> I'm a verbose program! I'll be reading the following files: 
+> I'm a verbose program! I'll be reading the following files:
 > * /tmp/one
 > * /tmp/two
 > * /tmp/three

--- a/cmake/flagsConfig.cmake.in
+++ b/cmake/flagsConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
It is advantageous to package this project as a cmake-compatible module since we can then allow users to just add it to their existing build system. Note, this does not add cmake support for the test directory to keep the change set small.

The cmake build system provided here supports an installation via cmake or working as a submodule. The docs have been updated to reflect this.