### PR TITLE
Fix build, Add support for multiple values and empty values

### DIFF
--- a/build.bfg
+++ b/build.bfg
@@ -9,12 +9,12 @@ project('flags', version='1.0pre')
 global_options(['-std=c++1z', '-Wall', '-Wextra', '-Werror', '-pedantic'],
                lang='c++')
 mettle = package('mettle')
-includes = header_directory('include', include='flags.h')
+includes = header_directory('include', include='*.h')
 driver = test_driver(
   'mettle -o verbose'
 )
 
-for src in find_files('test', '*.cc'):
+for src in find_files('test/*.cc'):
   path = os.path.join('test', src.path.basename())
   test(executable(
       splitext(path)[0],

--- a/include/flags.h
+++ b/include/flags.h
@@ -38,6 +38,11 @@ struct parser {
  private:
   // Advance the state machine for the current token.
   void churn(const std::string_view& item) {
+    if(item.empty())
+    {
+      on_value(item);
+      return;
+    }
     item.at(0) == '-' ? on_option(item) : on_value(item);
   }
 

--- a/test/flags.cc
+++ b/test/flags.cc
@@ -212,7 +212,6 @@ suite<> flag_parsing("flag parsing", [](auto& _) {
   _.test("multiple", [](){
     const auto fixture = args_fixture::create({"--foo", "bar", "--foo", "baz"});
     auto foo = fixture.args().get_multiple<std::string>("foo");
-    std::sort(foo.begin(), foo.end()); // multimap doesn't keep order
     expect(foo.size(), equal_to(2));
     expect(foo[0].value(), equal_to("bar"));
     expect(foo[1].value(), equal_to("baz"));
@@ -221,14 +220,12 @@ suite<> flag_parsing("flag parsing", [](auto& _) {
   _.test("multiple with type", [](){
     const auto fixture = args_fixture::create({"-x", "-x", "1", "-x", "2"});
     auto x = fixture.args().get_multiple<int>("x", 0);
-    std::sort(x.begin(), x.end()); // multimap doesn't keep order
     expect(x.size(), equal_to(3));
     expect(x[0], equal_to(0));
     expect(x[1], equal_to(1));
     expect(x[2], equal_to(2));
   });
 
-  // Multiple falsities
   _.test("multiple falsities", [](){
     std::vector<const char*> args;
     for (const auto falsity : flags::detail::falsities) {
@@ -243,6 +240,15 @@ suite<> flag_parsing("flag parsing", [](auto& _) {
     const auto foos2 = fixture.args().get_multiple<bool>("foo", true);
     for (const auto& foo : foos2) {
       expect(foo, equal_to(false));
+    }
+  });
+
+  _.test("multiple valueless flags", [](){
+    const auto fixture = args_fixture::create({"--foo", "-foo", "--foo", "-foo"});
+    const auto foos = fixture.args().get_multiple<bool>("foo");
+    expect(foos.size(), equal_to(4));
+    for (const auto& foo : foos) {
+      expect(static_cast<bool>(foo), equal_to(true));
     }
   });
 

--- a/test/flags.cc
+++ b/test/flags.cc
@@ -5,6 +5,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <cstring>
 
 using namespace mettle;
 
@@ -182,6 +183,12 @@ suite<> flag_parsing("flag parsing", [](auto& _) {
     const auto fixture = args_fixture::create({"--foo", LOREM_IPSUM});
     expect(*fixture.args().get<std::string>("foo"),
            equal_to(std::string(LOREM_IPSUM)));
+  });
+
+  // Empty values
+  _.test("empty", [](){
+    const auto fixture = args_fixture::create({"--foo", ""});
+    expect(*fixture.args().get<std::string>("foo"), equal_to(""));
   });
 
   // Basic number parsing. Verifying ints are truncated and doubles are

--- a/test/flags.cc
+++ b/test/flags.cc
@@ -6,6 +6,7 @@
 #include <string>
 #include <string_view>
 #include <cstring>
+#include <algorithm>
 
 using namespace mettle;
 
@@ -40,6 +41,19 @@ char** initialize_argv(const std::initializer_list<const char*> args) {
   return argv;
 }
 
+// Same as above but using a std::vector
+char** initialize_argv(const std::vector<const char*>& args) {
+  char** argv =
+      reinterpret_cast<char**>(malloc((args.size() + 2) * sizeof(char*)));
+  initialize_arg(argv, 0, "TEST");
+  std::size_t i = 0;
+  for (const auto& arg : args) {
+    initialize_arg(argv, ++i, arg);
+  }
+  argv[args.size() + 1] = NULL;
+  return argv;
+}
+
 // Cleans up every item within argv, then argv itself.
 void cleanup_argv(char** argv) {
   size_t index = 0;
@@ -51,6 +65,9 @@ void cleanup_argv(char** argv) {
 // Simple fixture for (de)allocating argv and initalizing flags::args.
 struct args_fixture {
   static args_fixture create(const std::initializer_list<const char*> args) {
+    return {args.size(), initialize_argv(args)};
+  }
+  static args_fixture create(const std::vector<const char*>& args) {
     return {args.size(), initialize_argv(args)};
   }
   ~args_fixture() { cleanup_argv(argv_); }
@@ -189,6 +206,44 @@ suite<> flag_parsing("flag parsing", [](auto& _) {
   _.test("empty", [](){
     const auto fixture = args_fixture::create({"--foo", ""});
     expect(*fixture.args().get<std::string>("foo"), equal_to(""));
+  });
+
+  // Multiple values for one flag
+  _.test("multiple", [](){
+    const auto fixture = args_fixture::create({"--foo", "bar", "--foo", "baz"});
+    auto foo = fixture.args().get_multiple<std::string>("foo");
+    std::sort(foo.begin(), foo.end()); // multimap doesn't keep order
+    expect(foo.size(), equal_to(2));
+    expect(foo[0].value(), equal_to("bar"));
+    expect(foo[1].value(), equal_to("baz"));
+  });
+
+  _.test("multiple with type", [](){
+    const auto fixture = args_fixture::create({"-x", "-x", "1", "-x", "2"});
+    auto x = fixture.args().get_multiple<int>("x", 0);
+    std::sort(x.begin(), x.end()); // multimap doesn't keep order
+    expect(x.size(), equal_to(3));
+    expect(x[0], equal_to(0));
+    expect(x[1], equal_to(1));
+    expect(x[2], equal_to(2));
+  });
+
+  // Multiple falsities
+  _.test("multiple falsities", [](){
+    std::vector<const char*> args;
+    for (const auto falsity : flags::detail::falsities) {
+      args.push_back("--foo");
+      args.push_back(falsity);
+    }
+    const auto fixture = args_fixture::create(args);
+    const auto foos1 = fixture.args().get_multiple<bool>("foo");
+    for (const auto& foo : foos1) {
+      expect(foo && *foo, equal_to(false));
+    }
+    const auto foos2 = fixture.args().get_multiple<bool>("foo", true);
+    for (const auto& foo : foos2) {
+      expect(foo, equal_to(false));
+    }
   });
 
   // Basic number parsing. Verifying ints are truncated and doubles are


### PR DESCRIPTION
First of all I want to say thank you for creating this library, I use it in every CLI tool I write due to it's simplicity and robustness. While working on a new project I found I needed to support empty arguments:
```
./search --file-extension ""
```
However that causes a crash on [line 41](https://github.com/sailormoon/flags/blob/4fe826161e0dcb093278126ae08b0b2cbab0e2f7/include/flags.h#L41) so I fixed that.

I later needed support for multiple values per argument so after looking at #11 I added support for that too. During this process when I tried to build the project I got errors relating to build.bfg so I fixed those to the best of my ability using the examples provided in the bfg9000 repository.

If there are any changes you would like please let me know or if you would prefer separate PR's for each commit. Thanks.