### PR TITLE
Add support for skipping arguments after '--'

### DIFF
--- a/test/flags.cc
+++ b/test/flags.cc
@@ -266,4 +266,18 @@ suite<> flag_parsing("flag parsing", [](auto& _) {
     expect(fixture.args().get<int>("foobar"), equal_to(std::nullopt));
     expect(fixture.args().get<double>("foobar"), equal_to(std::nullopt));
   });
+
+  _.test("skipped tokens", [](){
+    const auto fixture =
+        args_fixture::create({"--foo", "--", "bar", "--baz", "1", "2", "3"});
+    expect(*fixture.args().get<bool>("foo"), equal_to(true));
+    expect(fixture.args().get<bool>("baz"), equal_to(std::nullopt));
+    const std::vector<std::string_view> &skipped = fixture.args().skipped();
+    expect(skipped.size(), equal_to(5));
+    expect(skipped.at(0), equal_to("bar"));
+    expect(skipped.at(1), equal_to("--baz"));
+    expect(skipped.at(2), equal_to("1"));
+    expect(skipped.at(3), equal_to("2"));
+    expect(skipped.at(4), equal_to("3"));
+  });
 });


### PR DESCRIPTION
Many command-line utilities such as grep and git accept `--` to mean the end of command-line arguments, and I wanted the functionality for a project I'm working on so added it. Reading [this StackExchange question](https://unix.stackexchange.com/questions/11376/what-does-double-dash-mean) there are some that say it indicates the end of option parsing altogether, whereas others say it marks all further arguments as positional arguments.

My implementation uses a separate vector for "skipped" arguments however I am unsure if they should instead be appended to the positional vector instead. Consider the following example:
```
./myprogram positional_1 positional_2 --foo=bar
```
The following would **not** be equivalent using my current approach:
```
./myprogram positional_1 --foo=bar -- positional_2
```
I personally think this is a more expressive behaviour however I am looking to discuss it further